### PR TITLE
getRelatedTags Selector를 추가하라

### DIFF
--- a/src/redux_module/_selectors_/selectors.js
+++ b/src/redux_module/_selectors_/selectors.js
@@ -7,4 +7,12 @@ const getFileList = (state) => {
 
 const getTagList = (state) => state.matchedItems.tags.items;
 
-export { getFileList, getTagList };
+const getRelatedTags = (state) => {
+  const ID = state.searchBarID.current;
+  const files = state.matchedItems.files.items[ID];
+  return _.isEmpty(files)
+    ? _.keyBy(state.allTags.tags, 'id')
+    : _.assign({}, ..._.map(files, (file) => (file.tags)));
+};
+
+export { getFileList, getTagList, getRelatedTags };

--- a/src/redux_module/_selectors_/selectors.test.js
+++ b/src/redux_module/_selectors_/selectors.test.js
@@ -1,5 +1,6 @@
 import { getFileList, getTagList, getRelatedTags } from './selectors';
 import { matchedItems } from '../matchedItems/matchedItems.fixture';
+import { tags } from '../allTags/allTags.fixture';
 
 describe('Test Selector', () => {
   it('getFileList', () => {
@@ -46,6 +47,63 @@ describe('Test Selector', () => {
       1: { id: 1, name: '6월', group: ['짝수', '평가원', '달'] },
       2: { id: 2, name: '2016년', group: ['년', '짝수'] },
       3: { id: 3, name: '20번', group: ['번호', '짝수'] },
+    });
+  });
+
+  describe('Selector: getdReleatedTags', () => {
+    it('when files exist', () => {
+      const state = {
+        allTags: {
+          tags,
+        },
+        matchedItems,
+        searchBarID: {
+          current: 0,
+        },
+      };
+
+      const relatedTags = getRelatedTags(state);
+
+      expect(relatedTags).toEqual({
+        1: { id: 1, name: '2018년', group: ['짝수', '년'] },
+        2: { id: 2, name: '6월', group: ['짝수', '월', '평가원'] },
+        3: { id: 3, name: '20번', group: ['짝수', '번호'] },
+        4: { id: 4, name: '2020년', group: ['짝수', '년'] },
+        5: { id: 5, name: '3월', group: ['홀수', '월', '교육청'] },
+        6: { id: 6, name: '21번', group: ['홀수', '번호'] },
+      });
+    });
+
+    it('when files is empty', () => {
+      const state = {
+        allTags: {
+          tags,
+        },
+        matchedItems: {
+          files: {
+            error: null,
+            items: {
+              0: {},
+            },
+          },
+        },
+        searchBarID: {
+          current: 0,
+        },
+      };
+
+      const relatedTags = getRelatedTags(state);
+
+      expect(relatedTags).toEqual({
+        1: { id: 1, name: '2018년', group: ['짝수', '년'] },
+        2: { id: 2, name: '6월', group: ['짝수', '월', '평가원'] },
+        3: { id: 3, name: '20번', group: ['짝수', '번호'] },
+        4: { id: 4, name: '2020년', group: ['짝수', '년'] },
+        5: { id: 5, name: '3월', group: ['홀수', '월', '교육청'] },
+        6: { id: 6, name: '21번', group: ['홀수', '번호'] },
+        7: { id: 7, name: '11월', group: ['홀수', '월', '평가원', '수능'] },
+        8: { id: 8, name: '30번', group: ['짝수', '번호'] },
+      });
     });
   });
 });

--- a/src/redux_module/allTags/allTags.fixture.js
+++ b/src/redux_module/allTags/allTags.fixture.js
@@ -1,0 +1,13 @@
+const tags = [
+  { id: 1, name: '2018년', group: ['짝수', '년'] },
+  { id: 2, name: '6월', group: ['짝수', '월', '평가원'] },
+  { id: 3, name: '20번', group: ['짝수', '번호'] },
+  { id: 4, name: '2020년', group: ['짝수', '년'] },
+  { id: 5, name: '3월', group: ['홀수', '월', '교육청'] },
+  { id: 6, name: '21번', group: ['홀수', '번호'] },
+  { id: 7, name: '11월', group: ['홀수', '월', '평가원', '수능'] },
+  { id: 8, name: '30번', group: ['짝수', '번호'] },
+];
+
+export { tags };
+export default {};


### PR DESCRIPTION
1. 기존 demo버젼에서 `recommandedTags`의 역할을 하던 selector를 구현하였습니다. recommanded보다는 related가 더 자연스러운 명칭인 것 같아서 이름을 바꾸었습니다.
2. 테스트 데이터 사용을 위해 allTags.fixture를 추가하였습니다.